### PR TITLE
Resolve the actual Hostname if in the config Hostname is %h

### DIFF
--- a/tssh/login.go
+++ b/tssh/login.go
@@ -115,11 +115,13 @@ func getLoginParam(args *sshArgs) (*loginParam, error) {
 	args.Destination = destHost
 
 	// login host
-	hostName := getConfig(destHost, "HostName")
-	if hostName != "" {
-		param.host = hostName
-	} else {
-		param.host = destHost
+	param.host = destHost
+	if hostName := getConfig(destHost, "HostName"); hostName != "" {
+		var err error
+		param.host, err = expandTokens(hostName, args, param, "%h")
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// login user


### PR DESCRIPTION
Refer to the man page:
https://manpages.debian.org/bookworm/openssh-client/ssh_config.5.en.html#Hostname
https://manpages.debian.org/bookworm/openssh-client/ssh_config.5.en.html#TOKENS

If the Hostname is a token such as %h, it should be resolved to the real Hostname from Host