### PR TITLE
feat: support --list-hosts tools command

### DIFF
--- a/tssh/args.go
+++ b/tssh/args.go
@@ -94,6 +94,7 @@ type sshArgs struct {
 	TsshdBinPath   string      `arg:"--tsshd-bin-path" placeholder:"path" help:"[tools] tsshd binary installation package path"`
 	UploadFile     multiStr    `arg:"--upload-file" placeholder:"path" help:"[tools] upload the local file to remote server"`
 	DownloadPath   string      `arg:"--download-path" placeholder:"path" help:"[tools] the local saving path for downloading"`
+	ListHosts      bool        `arg:"--list-hosts" help:"[tools] list all hosts in configuration"`
 	originalDest   string
 }
 

--- a/tssh/args.go
+++ b/tssh/args.go
@@ -85,6 +85,7 @@ type sshArgs struct {
 	TsshdPath      string      `arg:"--tsshd-path" placeholder:"path" help:"[udp] tsshd absolute path on the server"`
 	NewHost        bool        `arg:"--new-host" help:"[tools] add new host to configuration"`
 	EncSecret      bool        `arg:"--enc-secret" help:"[tools] encode secret for configuration"`
+	ListHosts      bool        `arg:"--list-hosts" help:"[tools] list all hosts in configuration"`
 	InstallTrzsz   bool        `arg:"--install-trzsz" help:"[tools] install trzsz to the remote server"`
 	InstallTsshd   bool        `arg:"--install-tsshd" help:"[tools] install tsshd to the remote server"`
 	InstallPath    string      `arg:"--install-path" placeholder:"path" help:"[tools] install path, default: '~/.local/bin/'"`
@@ -94,7 +95,6 @@ type sshArgs struct {
 	TsshdBinPath   string      `arg:"--tsshd-bin-path" placeholder:"path" help:"[tools] tsshd binary installation package path"`
 	UploadFile     multiStr    `arg:"--upload-file" placeholder:"path" help:"[tools] upload the local file to remote server"`
 	DownloadPath   string      `arg:"--download-path" placeholder:"path" help:"[tools] the local saving path for downloading"`
-	ListHosts      bool        `arg:"--list-hosts" help:"[tools] list all hosts in configuration"`
 	originalDest   string
 }
 

--- a/tssh/config.go
+++ b/tssh/config.go
@@ -64,7 +64,7 @@ type sshHost struct {
 	ProxyJump     string
 	RemoteCommand string
 	GroupLabels   string
-	Selected      bool
+	Selected      bool `json:"-"`
 }
 
 type tsshConfig struct {

--- a/tssh/tools.go
+++ b/tssh/tools.go
@@ -463,9 +463,14 @@ func execLocalTools(argv []string, args *sshArgs) (int, bool) {
 		return execNewHost(args)
 	case args.ListHosts:
 		hosts := getAllHosts()
+
+		if hosts == nil {
+			hosts = []*sshHost{}
+		}
 		result, err := json.MarshalIndent(hosts, "", "  ")
 		if err != nil {
-			panic(err)
+			warning("json marshal indent failed: %v", err)
+			return 1, true
 		}
 
 		hostsJson := string(result)

--- a/tssh/tools.go
+++ b/tssh/tools.go
@@ -25,12 +25,10 @@ SOFTWARE.
 package tssh
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"math"
 	"os"
-	"runtime"
 	"strings"
 	"time"
 
@@ -462,24 +460,7 @@ func execLocalTools(argv []string, args *sshArgs) (int, bool) {
 	case args.NewHost || len(argv) == 0 && isFileNotExistOrEmpty(userConfig.configPath):
 		return execNewHost(args)
 	case args.ListHosts:
-		hosts := getAllHosts()
-
-		if hosts == nil {
-			hosts = []*sshHost{}
-		}
-		result, err := json.MarshalIndent(hosts, "", "  ")
-		if err != nil {
-			warning("json marshal indent failed: %v", err)
-			return 1, true
-		}
-
-		hostsJson := string(result)
-		if runtime.GOOS == "windows" {
-			hostsJson = strings.ReplaceAll(hostsJson, "\n", "\r\n")
-		}
-		fmt.Println(hostsJson)
-
-		return 0, true
+		return execListHosts()
 	default:
 		return 0, false
 	}

--- a/tssh/tools.go
+++ b/tssh/tools.go
@@ -25,15 +25,17 @@ SOFTWARE.
 package tssh
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"math"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
 	"github.com/charmbracelet/bubbles/textinput"
-	"github.com/charmbracelet/bubbletea"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
 
@@ -459,6 +461,20 @@ func execLocalTools(argv []string, args *sshArgs) (int, bool) {
 		return execEncodeSecret()
 	case args.NewHost || len(argv) == 0 && isFileNotExistOrEmpty(userConfig.configPath):
 		return execNewHost(args)
+	case args.ListHosts:
+		hosts := getAllHosts()
+		result, err := json.MarshalIndent(hosts, "", "  ")
+		if err != nil {
+			panic(err)
+		}
+
+		hostsJson := string(result)
+		if runtime.GOOS == "windows" {
+			hostsJson = strings.ReplaceAll(hostsJson, "\n", "\r\n")
+		}
+		fmt.Println(hostsJson)
+
+		return 0, true
 	default:
 		return 0, false
 	}

--- a/tssh/tools_list_hosts.go
+++ b/tssh/tools_list_hosts.go
@@ -1,0 +1,53 @@
+/*
+MIT License
+
+Copyright (c) 2023-2024 The Trzsz SSH Authors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package tssh
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+func execListHosts() (int, bool) {
+	hosts := getAllHosts()
+
+	if hosts == nil {
+		hosts = []*sshHost{}
+	}
+	result, err := json.MarshalIndent(hosts, "", "  ")
+	if err != nil {
+		warning("json marshal indent failed: %v", err)
+		return 1, true
+	}
+
+	hostsJson := string(result)
+	if runtime.GOOS == "windows" {
+		hostsJson = strings.ReplaceAll(hostsJson, "\n", "\r\n")
+	}
+	fmt.Println(hostsJson)
+
+	return 0, true
+}


### PR DESCRIPTION
support list all tssh hosts.

in my case, I want to use wezterm to integrate tssh for ssh session management.

```lua
-- tssh.lua
local wezterm = require 'wezterm'

local M = {}

local function host_list()
    local hosts = {}
    local success, stdout, stderr = wezterm.run_child_process {
        'tssh',
        '--list-hosts',
    }
    hosts = wezterm.json_parse(stdout)

    return hosts
end

local function make_tssh_label_func(host)
    return wezterm.format {
        { Foreground = { AnsiColor = 'Green' } },
        { Text = "groups:" .. host["GroupLabels"] },
    }
end

local function make_tssh_fixup_func(alias)
    return function(cmd)
        local wrapped = {
            "tssh",
            alias,
        }
        cmd.args = wrapped
        -- wezterm.log_error(cmd)

        return cmd
    end
end

function M.compute_exec_domains()
    local exec_domains = {}
    for _, host in pairs(host_list()) do
        local alias = host["Alias"]
        local fixup = make_tssh_fixup_func(alias)
        local label_func = make_tssh_label_func(host)
        table.insert(
            exec_domains,
            wezterm.exec_domain(
                'tssh:' .. alias,
                fixup,
                label_func
            )
        )
    end
    return exec_domains
end

return M
```

```lua
-- wezterm.lua
local wezterm = require 'wezterm'
local tssh = require('tssh')

local config = {}
if wezterm.config_builder then
  config = wezterm.config_builder()
end

config.exec_domains = tssh.compute_exec_domains()
```
