### PR TITLE
feat: honor StreamLocalBindUnlink and StreamLocalBindMask for LocalForward

### DIFF
--- a/tssh/forward.go
+++ b/tssh/forward.go
@@ -369,7 +369,7 @@ func sshPortForward(sshConn *sshConnection) {
 
 	// dynamic forward
 	for _, b := range args.DynamicForward.binds {
-		dynamicForward(sshConn.client, b, gateway, timeout)
+		dynamicForward(sshConn, b, gateway, timeout)
 	}
 	for _, s := range getAllExOptionConfig(args, "DynamicForward") {
 		b, err := parseBindCfg(s)
@@ -377,7 +377,7 @@ func sshPortForward(sshConn *sshConnection) {
 			warning("parse dynamic forwarding failed: %v", err)
 			continue
 		}
-		dynamicForward(sshConn.client, b, gateway, timeout)
+		dynamicForward(sshConn, b, gateway, timeout)
 	}
 
 	// local forward

--- a/tssh/forward_tcp.go
+++ b/tssh/forward_tcp.go
@@ -41,23 +41,74 @@ import (
 	"github.com/trzsz/go-socks5"
 )
 
-func listenOnLocalTCP(gateway bool, addr *string, port, name string) (listeners []net.Listener) {
+// OpenSSH's default StreamLocalBindMask.
+const defaultStreamLocalBindMask = 0177
+
+// streamLocalBindMask returns the StreamLocalBindMask for the given ssh args,
+// falling back to OpenSSH's default when unset or invalid.
+func streamLocalBindMask(args *sshArgs) int {
+	v := getOptionConfig(args, "StreamLocalBindMask")
+	if v == "" {
+		return defaultStreamLocalBindMask
+	}
+	mask, err := strconv.ParseInt(v, 8, 32)
+	if err != nil || mask < 0 || mask > 0777 {
+		warning("invalid StreamLocalBindMask [%s], using default 0177", v)
+		return defaultStreamLocalBindMask
+	}
+	return int(mask)
+}
+
+// unlinkStaleUnixSocket honors StreamLocalBindUnlink for local unix sockets.
+// Missing paths are a no-op. Non-socket files are refused. Socket files are
+// removed and a debug log is emitted.
+func unlinkStaleUnixSocket(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf("refusing to unlink non-socket path: %s", path)
+	}
+	if err := os.Remove(path); err != nil {
+		return err
+	}
+	debug("unlinked existing unix socket [%s] per StreamLocalBindUnlink", path)
+	return nil
+}
+
+func listenOnLocalTCP(gateway bool, addr *string, port, name string, unlinkUnix bool, bindMask int) (listeners []net.Listener) {
 	listen := func(network, address string) {
+		if network == "unix" && unlinkUnix {
+			if err := unlinkStaleUnixSocket(address); err != nil {
+				warning("%s unlink [%s] failed: %v", name, address, err)
+				return
+			}
+		}
 		listener, err := net.Listen(network, address)
 		if err != nil {
 			warning("%s listen on local [%s] [%s] failed: %v", name, network, address, err)
-		} else {
-			debug("%s listen on local [%s] [%s] success", name, network, address)
-			listeners = append(listeners, listener)
-			addOnCloseFunc(func() {
-				_ = listener.Close()
-				if network == "unix" {
-					if err := os.Remove(address); err != nil {
-						debug("remove unix socket [%s] failed: %v", address, err)
-					}
-				}
-			})
+			return
 		}
+		if network == "unix" {
+			mode := os.FileMode(0666) &^ os.FileMode(bindMask)
+			if err := os.Chmod(address, mode); err != nil {
+				warning("%s chmod unix socket [%s] to %#o failed: %v", name, address, mode, err)
+			}
+		}
+		debug("%s listen on local [%s] [%s] success", name, network, address)
+		listeners = append(listeners, listener)
+		addOnCloseFunc(func() {
+			_ = listener.Close()
+			if network == "unix" {
+				if err := os.Remove(address); err != nil {
+					debug("remove unix socket [%s] failed: %v", address, err)
+				}
+			}
+		})
 	}
 
 	if addr == nil && gateway || addr != nil && (*addr == "" || *addr == "*") {
@@ -127,12 +178,12 @@ func (d sshResolver) Resolve(ctx context.Context, name string) (context.Context,
 	return ctx, []byte{}, nil
 }
 
-func dynamicForward(client SshClient, b *bindCfg, gateway bool, timeout time.Duration) {
+func dynamicForward(sshConn *sshConnection, b *bindCfg, gateway bool, timeout time.Duration) {
 	var dialError = errors.New("DIAL_ERROR_" + uuid.NewString())
 	server, err := socks5.New(&socks5.Config{
 		Resolver: &sshResolver{},
 		Dial: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			conn, err := client.DialTimeout(network, addr, timeout)
+			conn, err := sshConn.client.DialTimeout(network, addr, timeout)
 			if err != nil {
 				if reason := forwardDeniedReason(err, network); reason != "" {
 					warning("The dynamic forwarding [%v] was denied. %s", b, reason)
@@ -150,8 +201,10 @@ func dynamicForward(client SshClient, b *bindCfg, gateway bool, timeout time.Dur
 		return
 	}
 
+	unlinkUnix := strings.ToLower(getOptionConfig(sshConn.param.args, "StreamLocalBindUnlink")) == "yes"
+	bindMask := streamLocalBindMask(sshConn.param.args)
 	name := fmt.Sprintf("dynamic forwarding [%v]", b)
-	for _, listener := range listenOnLocalTCP(gateway, b.addr, strconv.Itoa(b.port), name) {
+	for _, listener := range listenOnLocalTCP(gateway, b.addr, strconv.Itoa(b.port), name, unlinkUnix, bindMask) {
 		go func(listener net.Listener) {
 			defer func() { _ = listener.Close() }()
 			for {
@@ -202,8 +255,10 @@ func localForwardTCP(sshConn *sshConnection, f *forwardCfg, gateway bool, timeou
 		remoteAddr = joinHostPort(f.destHost, strconv.Itoa(f.destPort))
 	}
 
+	unlinkUnix := strings.ToLower(getOptionConfig(sshConn.param.args, "StreamLocalBindUnlink")) == "yes"
+	bindMask := streamLocalBindMask(sshConn.param.args)
 	name := fmt.Sprintf("local forwarding [%v]", f)
-	for _, listener := range listenOnLocalTCP(gateway, f.bindAddr, strconv.Itoa(f.bindPort), name) {
+	for _, listener := range listenOnLocalTCP(gateway, f.bindAddr, strconv.Itoa(f.bindPort), name, unlinkUnix, bindMask) {
 		go func(listener net.Listener) {
 			defer func() { _ = listener.Close() }()
 			for {

--- a/tssh/forward_tcp.go
+++ b/tssh/forward_tcp.go
@@ -93,20 +93,33 @@ func listenOnLocalTCP(gateway bool, addr *string, port, name string, unlinkUnix 
 			warning("%s listen on local [%s] [%s] failed: %v", name, network, address, err)
 			return
 		}
+		var createdInfo os.FileInfo
 		if network == "unix" {
 			mode := os.FileMode(0666) &^ os.FileMode(bindMask)
 			if err := os.Chmod(address, mode); err != nil {
 				warning("%s chmod unix socket [%s] to %#o failed: %v", name, address, mode, err)
+			}
+			if info, err := os.Stat(address); err == nil {
+				createdInfo = info
 			}
 		}
 		debug("%s listen on local [%s] [%s] success", name, network, address)
 		listeners = append(listeners, listener)
 		addOnCloseFunc(func() {
 			_ = listener.Close()
-			if network == "unix" {
-				if err := os.Remove(address); err != nil {
-					debug("remove unix socket [%s] failed: %v", address, err)
-				}
+			if network != "unix" || createdInfo == nil {
+				return
+			}
+			current, err := os.Stat(address)
+			if err != nil {
+				return
+			}
+			if !os.SameFile(createdInfo, current) {
+				debug("%s unix socket [%s] replaced since creation; skipping unlink", name, address)
+				return
+			}
+			if err := os.Remove(address); err != nil {
+				debug("remove unix socket [%s] failed: %v", address, err)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #228.

Adds OpenSSH-aligned handling of `StreamLocalBindUnlink` and `StreamLocalBindMask` for `tssh`'s LocalForward (and dynamic forwarding) unix sockets. Server-side behavior for RemoteForward is governed by `sshd_config` on the remote host (per OpenSSH semantics) — no client-to-server signaling here. The matching server-side change for `tsshd` is in trzsz/tsshd#27.

### Behavior

Before `net.Listen` on a unix socket:
- If `StreamLocalBindUnlink=yes`, lstat the path; unlink only if it is a unix socket. Non-socket paths and unlink failures emit a warning and skip the bind. Successful removals are debug-logged.

After `Listen`:
- Chmod the socket to `0666 &^ StreamLocalBindMask` (default `0177` per OpenSSH). Chmod failure is a warning, not fatal.

### Safe cleanup

On exit, `tssh` used to unconditionally unlink any unix socket it had created. This PR records the `(dev, inode)` at creation time (via `os.Stat`) and only unlinks at cleanup if `os.SameFile` confirms the path still refers to the same file. Avoids stealing a socket that another process has replaced in the interim.