### PR TITLE
feat(udp): add configurable UdpReconnectExitKey ex-option

### DIFF
--- a/tssh/notif.go
+++ b/tssh/notif.go
@@ -96,11 +96,12 @@ func interactWithUserInput(client *sshUdpClient) {
 			if !ok {
 				return
 			}
-			switch ch {
-			case '\x01': // ctrl + a
+			switch {
+			case ch == '\x01': // Ctrl+A toggles full notifications.
 				client.notifInterceptor.showFullNotif.Store(!client.notifInterceptor.showFullNotif.Load())
-			case '\x03': // ctrl + c
-				client.exit(kExitCodeUdpCtrlC, "lost connection and Ctrl+C keystroke")
+			case client.notifInterceptor.exitKey != 0 && ch == client.notifInterceptor.exitKey:
+				client.exit(kExitCodeUdpCtrlC, fmt.Sprintf("lost connection and %s keystroke",
+					udpReconnectExitKeyName(client.notifInterceptor.exitKey)))
 				return
 			}
 		case <-time.After(200 * time.Millisecond):
@@ -273,8 +274,12 @@ func (m *notifModel) getView(redrawing bool) string {
 			buf.WriteByte('\n')
 			buf.WriteString(m.errorStyle.Render("Last reconnect error: " + err.Error()))
 		}
-		buf.WriteByte('\n')
-		buf.WriteString(m.tipsStyle.Render("No longer need to reconnect to the server? Press Ctrl+C to exit."))
+		if m.client.notifInterceptor.exitKey != 0 {
+			buf.WriteByte('\n')
+			buf.WriteString(m.tipsStyle.Render(fmt.Sprintf(
+				"No longer need to reconnect to the server? Press %s to exit.",
+				udpReconnectExitKeyName(m.client.notifInterceptor.exitKey))))
+		}
 	}
 
 	return lipgloss.PlaceHorizontal(m.getWidth(), lipgloss.Center, m.borderStyle.Render(buf.String()))
@@ -298,6 +303,7 @@ type notifInterceptor struct {
 	tmuxPaneId    atomic.Pointer[string]
 	tmuxLeftBuf   []byte
 	filterESC6n   atomic.Bool
+	exitKey       byte // Exit key during UDP reconnect; 0 means disabled.
 }
 
 func (ni *notifInterceptor) handleUserInput(input []byte) {
@@ -489,6 +495,54 @@ func (c *outputCache) flushOutput(writer io.Writer) error {
 	return nil
 }
 
+const defaultUdpReconnectExitKey byte = '\x04' // Ctrl+D
+
+// parseUdpReconnectExitKey parses the UdpReconnectExitKey ex-option.
+// It accepts "none", "ctrl+<letter>", and "^<letter>"; invalid values fall back to Ctrl+D.
+func parseUdpReconnectExitKey(value string) byte {
+	v := strings.TrimSpace(value)
+	if v == "" {
+		return defaultUdpReconnectExitKey
+	}
+	lower := strings.ToLower(v)
+	if lower == "none" {
+		return 0
+	}
+
+	if strings.HasPrefix(lower, "ctrl+") && len(lower) == len("ctrl+")+1 {
+		return parseUdpReconnectControlKey(value, lower[len("ctrl+")])
+	}
+	if len(v) == 2 && v[0] == '^' {
+		return parseUdpReconnectControlKey(value, v[1])
+	}
+
+	warning("UdpReconnectExitKey: invalid value %q, fallback to Ctrl+D", value)
+	return defaultUdpReconnectExitKey
+}
+
+func parseUdpReconnectControlKey(value string, b byte) byte {
+	if b >= 'A' && b <= 'Z' {
+		b += 'a' - 'A'
+	}
+	if b < 'a' || b > 'z' {
+		warning("UdpReconnectExitKey: %s is not a valid control key, fallback to Ctrl+D", value)
+		return defaultUdpReconnectExitKey
+	}
+	key := byte(b-'a') + 1
+	if key == '\x01' {
+		warning("UdpReconnectExitKey: Ctrl+A is reserved, fallback to Ctrl+D")
+		return defaultUdpReconnectExitKey
+	}
+	return key
+}
+
+func udpReconnectExitKeyName(key byte) string {
+	if key >= 0x01 && key <= 0x1a {
+		return fmt.Sprintf("Ctrl+%c", 'A'+key-1)
+	}
+	return string(key)
+}
+
 func setupUdpNotification(sshConn *sshConnection) {
 	if lastJumpUdpClient == nil || !isTerminal || !sshConn.tty {
 		return
@@ -497,6 +551,7 @@ func setupUdpNotification(sshConn *sshConnection) {
 	ni := notifInterceptor{client: lastJumpUdpClient, interceptChan: make(chan byte, 1)}
 	ni.noticeOnTop = strings.ToLower(getExOptionConfig(sshConn.param.args, "ShowNotificationOnTop")) != "no"
 	ni.showFullNotif.Store(strings.ToLower(getExOptionConfig(sshConn.param.args, "ShowFullNotifications")) != "no")
+	ni.exitKey = parseUdpReconnectExitKey(getExOptionConfig(sshConn.param.args, "UdpReconnectExitKey"))
 
 	inReader, inWriter := io.Pipe()
 	outReader, outWriter := io.Pipe()

--- a/tssh/notif.go
+++ b/tssh/notif.go
@@ -275,10 +275,13 @@ func (m *notifModel) getView(redrawing bool) string {
 			buf.WriteString(m.errorStyle.Render("Last reconnect error: " + err.Error()))
 		}
 		if m.client.notifInterceptor.exitKey != 0 {
-			buf.WriteByte('\n')
+			verb := "exit"
+			if m.client.attachMode {
+				verb = "detach"
+			}
 			buf.WriteString(m.tipsStyle.Render(fmt.Sprintf(
-				"No longer need to reconnect to the server? Press %s to exit.",
-				udpReconnectExitKeyName(m.client.notifInterceptor.exitKey))))
+				"\nNo longer need to reconnect to the server? Press %s to %s.",
+				udpReconnectExitKeyName(m.client.notifInterceptor.exitKey), verb)))
 		}
 	}
 
@@ -498,7 +501,7 @@ func (c *outputCache) flushOutput(writer io.Writer) error {
 const defaultUdpReconnectExitKey byte = '\x04' // Ctrl+D
 
 // parseUdpReconnectExitKey parses the UdpReconnectExitKey ex-option.
-// It accepts "none", "ctrl+<letter>", and "^<letter>"; invalid values fall back to Ctrl+D.
+// It accepts "none", "ctrl+<letter>", and "^<letter>"; invalid values fall back to defaultUdpReconnectExitKey.
 func parseUdpReconnectExitKey(value string) byte {
 	v := strings.TrimSpace(value)
 	if v == "" {
@@ -516,7 +519,7 @@ func parseUdpReconnectExitKey(value string) byte {
 		return parseUdpReconnectControlKey(value, v[1])
 	}
 
-	warning("UdpReconnectExitKey: invalid value %q, fallback to Ctrl+D", value)
+	warning("UdpReconnectExitKey: invalid value %q, fallback to %s", value, udpReconnectExitKeyName(defaultUdpReconnectExitKey))
 	return defaultUdpReconnectExitKey
 }
 
@@ -525,12 +528,12 @@ func parseUdpReconnectControlKey(value string, b byte) byte {
 		b += 'a' - 'A'
 	}
 	if b < 'a' || b > 'z' {
-		warning("UdpReconnectExitKey: %s is not a valid control key, fallback to Ctrl+D", value)
+		warning("UdpReconnectExitKey: %s is not a valid control key, fallback to %s", value, udpReconnectExitKeyName(defaultUdpReconnectExitKey))
 		return defaultUdpReconnectExitKey
 	}
 	key := byte(b-'a') + 1
 	if key == '\x01' {
-		warning("UdpReconnectExitKey: Ctrl+A is reserved, fallback to Ctrl+D")
+		warning("UdpReconnectExitKey: Ctrl+A is reserved, fallback to %s", udpReconnectExitKeyName(defaultUdpReconnectExitKey))
 		return defaultUdpReconnectExitKey
 	}
 	return key

--- a/tssh/notif_test.go
+++ b/tssh/notif_test.go
@@ -61,6 +61,11 @@ func TestParseUdpReconnectExitKey(t *testing.T) {
 		{"  Ctrl+X  ", 0x18},
 		{"  ^X  ", 0x18},
 	}
+
+	enableWarning := enableWarningLogging
+	enableWarningLogging = false
+	defer func() { enableWarningLogging = enableWarning }()
+
 	for _, tt := range tests {
 		if gotKey := parseUdpReconnectExitKey(tt.input); gotKey != tt.wantKey {
 			t.Errorf("parseUdpReconnectExitKey(%q) = 0x%02x, want 0x%02x", tt.input, gotKey, tt.wantKey)

--- a/tssh/notif_test.go
+++ b/tssh/notif_test.go
@@ -1,0 +1,85 @@
+/*
+MIT License
+
+Copyright (c) 2023-2026 The Trzsz SSH Authors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package tssh
+
+import "testing"
+
+func TestParseUdpReconnectExitKey(t *testing.T) {
+	tests := []struct {
+		input   string
+		wantKey byte // 0 means disabled.
+	}{
+		{"", 0x04},
+		{"Ctrl+D", 0x04},
+		{"ctrl+d", 0x04},
+		{"CTRL+D", 0x04},
+		{"Ctrl+C", 0x03},
+		{"ctrl+c", 0x03},
+		{"CTRL+C", 0x03},
+		{"Ctrl+Q", 0x11},
+		{"ctrl+q", 0x11},
+		{"^q", 0x11},
+		{"^Q", 0x11},
+		{"Ctrl+X", 0x18},
+		{"ctrl+x", 0x18},
+		{"^x", 0x18},
+		{"^X", 0x18},
+		{"q", 0x04},
+		{".", 0x04},
+		{"none", 0},
+		{"NONE", 0},
+		{"OFF", 0x04},
+		{"disable", 0x04},
+		{"disabled", 0x04},
+		{"Ctrl+A", 0x04},
+		{"^A", 0x04},
+		{"Ctrl+1", 0x04},
+		{"^1", 0x04},
+		{"abc", 0x04},
+		{"  Ctrl+X  ", 0x18},
+		{"  ^X  ", 0x18},
+	}
+	for _, tt := range tests {
+		if gotKey := parseUdpReconnectExitKey(tt.input); gotKey != tt.wantKey {
+			t.Errorf("parseUdpReconnectExitKey(%q) = 0x%02x, want 0x%02x", tt.input, gotKey, tt.wantKey)
+		}
+	}
+}
+
+func TestUdpReconnectExitKeyName(t *testing.T) {
+	tests := []struct {
+		key  byte
+		want string
+	}{
+		{0x04, "Ctrl+D"},
+		{0x03, "Ctrl+C"},
+		{0x18, "Ctrl+X"},
+	}
+	for _, tt := range tests {
+		if got := udpReconnectExitKeyName(tt.key); got != tt.want {
+			t.Errorf("udpReconnectExitKeyName(0x%02x) = %q, want %q", tt.key, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Allow customizing the key to give up reconnecting and exit during UDP connection loss via the UdpReconnectExitKey ex-option. Accepts Ctrl+<letter> or a single printable character; set to none to disable. Defaults to Ctrl+C, preserving existing behavior.

For me , I use Ctrl+Q as exit key
Host myserver
      #!! UdpMode yes
      #!! UdpReconnectExitKey Ctrl+Q