### PR TITLE
Fix ProxyJump none handling and improve IdentityFile compatibility with ssh-agent/OpenSSH behavior

### DIFF
--- a/tssh/auth_method.go
+++ b/tssh/auth_method.go
@@ -28,6 +28,7 @@ import (
 	"bytes"
 	"crypto/x509"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -170,12 +171,11 @@ func newPassphraseSigner(path string, priKey []byte, err *ssh.PassphraseMissingE
 	return newSshSigner(path, priKey, pubKey, nil)
 }
 
-func getSigner(param *sshParam, path string) sshSigner {
+func getSigner(param *sshParam, path string) (sshSigner, error) {
 	path = resolveHomeDir(path)
 	privateKey, err := os.ReadFile(path)
 	if err != nil {
-		warning("read private key [%s] failed: %v", path, err)
-		return nil
+		return nil, err
 	}
 	signer, err := parsePrivateKey(privateKey)
 	if err != nil {
@@ -183,18 +183,37 @@ func getSigner(param *sshParam, path string) sshSigner {
 			if passphrase := getSecretConfig(param, "Passphrase"); passphrase != "" {
 				signer, err = parsePrivateKeyWithPassphrase(privateKey, []byte(passphrase))
 			} else {
-				return newPassphraseSigner(path, privateKey, e)
+				return newPassphraseSigner(path, privateKey, e), nil
 			}
 		}
 		if skErr, ok := err.(*unsupportedSecurityKeyError); ok {
 			signer, err = parseSecurityKey(path, skErr)
 		}
 		if err != nil {
-			warning("parse private key [%s] failed: %v", path, err)
-			return nil
+			return nil, err
 		}
 	}
-	return newSshSigner(path, nil, signer.PublicKey(), signer)
+	return newSshSigner(path, nil, signer.PublicKey(), signer), nil
+}
+
+func getIdentityAgentSigner(path string, agentSigners []ssh.Signer) (ssh.PublicKey, ssh.Signer) {
+	pubPath := resolveHomeDir(path)
+	if !strings.HasSuffix(pubPath, ".pub") {
+		pubPath += ".pub"
+	}
+	if !isFileExist(pubPath) {
+		return nil, nil
+	}
+	pubKey := parsePublicKey(pubPath)
+	if pubKey == nil {
+		return nil, nil
+	}
+	for _, agentSigner := range agentSigners {
+		if bytes.Equal(pubKey.Marshal(), agentSigner.PublicKey().Marshal()) {
+			return pubKey, agentSigner
+		}
+	}
+	return nil, nil
 }
 
 func appendSignerCerts(path string, signer sshSigner, certFiles []string) []sshSigner {
@@ -382,7 +401,12 @@ var getDefaultSigners = func() func() []sshSigner {
 				if !isFileExist(path) {
 					continue
 				}
-				if signer := getSigner(&sshParam{args: &sshArgs{Destination: name}}, path); signer != nil {
+				signer, err := getSigner(&sshParam{args: &sshArgs{Destination: name}}, path)
+				if err != nil {
+					warning("get signer failed: %v", err)
+					continue
+				}
+				if signer != nil {
 					signers = append(signers, signer)
 				}
 			}
@@ -457,27 +481,32 @@ func getPublicKeysAuthMethod(param *sshParam) ssh.AuthMethod {
 	out:
 		for _, path := range identities {
 			if strings.HasSuffix(path, ".pub") {
-				path = resolveHomeDir(path)
-				if pubKey := parsePublicKey(path); pubKey != nil {
-					for _, agentSigner := range agentSigners {
-						if bytes.Equal(pubKey.Marshal(), agentSigner.PublicKey().Marshal()) {
-							addSignerWithCerts("", newSshSigner(path+" (agent)", nil, pubKey, agentSigner))
-							continue out
-						}
+				if pubKey, agentSigner := getIdentityAgentSigner(path, agentSigners); agentSigner != nil {
+					addSignerWithCerts("", newSshSigner(path+" (agent)", nil, pubKey, agentSigner))
+					continue
+				}
+			}
+			signer, err := getSigner(param, path)
+			if errors.Is(err, os.ErrNotExist) {
+				if strings.HasSuffix(path, ".pub") {
+					continue
+				}
+				if pubKey, agentSigner := getIdentityAgentSigner(path, agentSigners); agentSigner != nil {
+					resolvedPath := resolveHomeDir(path)
+					addSignerWithCerts(resolvedPath, newSshSigner(resolvedPath+" (agent)", nil, pubKey, agentSigner))
+					continue
+				}
+			} else if err != nil {
+				warning("get signer for IdentityFile [%s] failed: %v", path, err)
+			} else if signer != nil {
+				for _, agentSigner := range agentSigners {
+					if bytes.Equal(signer.PublicKey().Marshal(), agentSigner.PublicKey().Marshal()) {
+						addSignerWithCerts(signer.getPath(), newSshSigner(signer.getPath()+" (agent)", nil, signer.PublicKey(), agentSigner))
+						continue out
 					}
 				}
+				addSignerWithCerts(signer.getPath(), signer)
 			}
-			signer := getSigner(param, path)
-			if signer == nil {
-				continue
-			}
-			for _, agentSigner := range agentSigners {
-				if bytes.Equal(signer.PublicKey().Marshal(), agentSigner.PublicKey().Marshal()) {
-					addSignerWithCerts(signer.getPath(), newSshSigner(signer.getPath()+" (agent)", nil, signer.PublicKey(), agentSigner))
-					continue out
-				}
-			}
-			addSignerWithCerts(signer.getPath(), signer)
 		}
 	}
 

--- a/tssh/login.go
+++ b/tssh/login.go
@@ -277,13 +277,13 @@ func getProxyParam(param *sshParam) {
 	}
 
 	proxyJump = getConfig(args.Destination, "ProxyJump")
-	if proxyJump != "" {
+	if proxyJump != "" && strings.ToLower(proxyJump) != "none" {
 		param.proxies = strings.Split(proxyJump, ",")
 		return
 	}
 
 	proxyCommand = getConfig(args.Destination, "ProxyCommand")
-	if proxyCommand != "" {
+	if proxyCommand != "" && strings.ToLower(proxyCommand) != "none" {
 		param.command = proxyCommand
 		return
 	}
@@ -829,8 +829,10 @@ func sshConnect(args *sshArgs) (*sshConnection, error) {
 	return sshConn, nil
 }
 
-var afterLoginFuncs []func()
-var afterLoginMutex sync.Mutex
+var (
+	afterLoginFuncs []func()
+	afterLoginMutex sync.Mutex
+)
 
 func cleanupAfterLogin() {
 	afterLoginMutex.Lock()


### PR DESCRIPTION
This PR fixes two compatibility issues between `tssh` and OpenSSH behavior.

### Summary

1. **Handle `ProxyJump none` correctly**
   - In OpenSSH, `ProxyJump none` is valid and means no jump host should be used.
   - In `tssh`, this currently causes it to treat `none` as a real host and attempt to connect to `none:22`, which results in a connection error.

2. **Improve `IdentityFile` handling when using ssh-agent**
   - OpenSSH can use `IdentityFile` entries to match against public keys, even when the corresponding private keys are not directly readable from disk.
   - This is useful when private keys are stored externally, such as in Bitwarden-backed `ssh-agent`, and only the public key or identity reference is available locally.
   - `tssh` currently depends too much on loading the private key file directly, which makes this workflow less compatible than OpenSSH.

### Background

My SSH config contains multiple proxy hosts used for multi-hop access:

```sshconfig
Host proxy.gz
    IdentityFile ~/.ssh/bw/proxy_gz
    HostName gz.host
    ProxyJump none

Host proxy.ix
    IdentityFile ~/.ssh/bw/proxy_ix
    HostName ix.com
    ProxyJump proxy.gz

Host proxy.*
    User root
    ProxyJump proxy.ix

Host proxy.hk
    IdentityFile ~/.ssh/bw/proxy_hk
    HostName hk.com

Host proxy.us
    IdentityFile ~/.ssh/bw/proxy_incudal
    HostName us.com
```

In this setup, some intermediate hosts explicitly use `ProxyJump none` to prevent infinite or unintended recursive proxy chaining. This works in OpenSSH as expected.

However, in `tssh`, `ProxyJump none` is interpreted as an actual jump target, which makes it try to connect to `none:22` and fail.

### IdentityFile compatibility issue

Another issue is related to `IdentityFile`.

With OpenSSH, `IdentityFile` can still be useful even if the private key is not loaded from that file directly. OpenSSH will try to use the corresponding public key information to match identities from `ssh-agent`.

In my case, private keys are stored in Bitwarden and exposed through `ssh-agent`, so the private key files are not available as normal local key files.  
While changing the config to use `~/.ssh/bw/proxy_gz.pub` can make it work, improving `tssh` to behave more like OpenSSH would provide better compatibility and require less configuration adjustment.

### What this PR changes

- Returns detailed errors from signer loading instead of silently swallowing them.
- Adds logic to match `IdentityFile` public keys against identities already available from `ssh-agent`.
- Improves handling for missing private key files so agent-backed identities can still be used when possible.
- Aligns behavior more closely with OpenSSH expectations for `IdentityFile`.
- Fixes handling around proxy command / proxy jump validation so `ProxyJump none` does not trigger an invalid connection attempt.

### Why this change is needed

These changes improve compatibility with real-world SSH configurations that already work in OpenSSH, especially:

- multi-hop proxy setups that intentionally use `ProxyJump none` on intermediate hosts
- workflows where private keys are managed by external tools like Bitwarden and accessed through `ssh-agent`
- configs that rely on OpenSSH-compatible `IdentityFile` matching behavior

Without this fix, users may see:
- connection failures to `none:22`
- inability to use agent-backed identities unless they explicitly point `IdentityFile` to `.pub` files

### Result

After this change, `tssh` behaves more like OpenSSH for both proxy resolution and identity selection, making existing SSH configs work more reliably without requiring workaround-specific changes.
