### PR TITLE
test: cover disabling proxy config with none

### DIFF
--- a/tssh/login_test.go
+++ b/tssh/login_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/trzsz/ssh_config"
 )
 
 func TestParseDestination(t *testing.T) {
@@ -67,4 +68,32 @@ func TestParseDestination(t *testing.T) {
 	assertDestEqual("user@fe80::6358:bbae:26f8:7859", "user", "fe80::6358:bbae:26f8:7859", "")
 	assertDestEqual("[fe80::6358:bbae:26f8:7859]:1022", "", "fe80::6358:bbae:26f8:7859", "1022")
 	assertDestEqual("user@[fe80::6358:bbae:26f8:7859]:1022", "user", "fe80::6358:bbae:26f8:7859", "1022")
+}
+
+func TestGetProxyParamIgnoresNoneFromConfig(t *testing.T) {
+	assert := assert.New(t)
+
+	origUserConfig := userConfig
+	defer func() { userConfig = origUserConfig }()
+
+	cfg, err := ssh_config.DecodeBytes([]byte(`
+Host proxy-disabled
+    ProxyJump none
+
+Host command-disabled
+    ProxyCommand none
+`))
+	assert.NoError(err)
+
+	userConfig = &tsshConfig{config: cfg}
+
+	jumpParam := &sshParam{args: &sshArgs{Destination: "proxy-disabled"}}
+	getProxyParam(jumpParam)
+	assert.Empty(jumpParam.proxies)
+	assert.Empty(jumpParam.command)
+
+	commandParam := &sshParam{args: &sshArgs{Destination: "command-disabled"}}
+	getProxyParam(commandParam)
+	assert.Empty(commandParam.proxies)
+	assert.Empty(commandParam.command)
 }


### PR DESCRIPTION
## Summary

Adds regression coverage for OpenSSH-compatible proxy disabling with `none` values from SSH config.

`ProxyJump none` and `ProxyCommand none` are valid OpenSSH config values used to clear inherited proxy settings. The current main branch already handles these values when reading config; this test locks that behavior down so future changes do not regress into treating `none` as a real proxy host or command.

## Validation

- `go test ./tssh`
