### PR TITLE
feat: support -O <ctl_cmd> to control the multiplexing master process

### DIFF
--- a/tssh/args.go
+++ b/tssh/args.go
@@ -78,7 +78,7 @@ type sshArgs struct {
 	NoX11Forward   bool        `arg:"-x,--" help:"disables X11 forwarding"`
 	X11Trusted     bool        `arg:"-Y,--" help:"enables trusted X11 forwarding"`
 	ControlPath    string      `arg:"-S,--" placeholder:"ctl_path" help:"specify the control socket path"`
-	ControlCmd     string      `arg:"-O,--" placeholder:"ctl_cmd" help:"control an active connection multiplexing master process"`
+	ControlCmd     string      `arg:"-O,--" placeholder:"ctl_cmd" help:"send command to a multiplex master"`
 	Reconnect      bool        `arg:"--reconnect" help:"reconnect or restart after process exits"`
 	DragFile       bool        `arg:"--dragfile" help:"enable drag files and directories to upload"`
 	TraceLog       bool        `arg:"--tracelog" help:"enable trzsz detect trace logs for debugging"`

--- a/tssh/args.go
+++ b/tssh/args.go
@@ -78,6 +78,7 @@ type sshArgs struct {
 	NoX11Forward   bool        `arg:"-x,--" help:"disables X11 forwarding"`
 	X11Trusted     bool        `arg:"-Y,--" help:"enables trusted X11 forwarding"`
 	ControlPath    string      `arg:"-S,--" placeholder:"ctl_path" help:"specify the control socket path"`
+	ControlCmd     string      `arg:"-O,--" placeholder:"ctl_cmd" help:"control an active connection multiplexing master process"`
 	Reconnect      bool        `arg:"--reconnect" help:"reconnect or restart after process exits"`
 	DragFile       bool        `arg:"--dragfile" help:"enable drag files and directories to upload"`
 	TraceLog       bool        `arg:"--tracelog" help:"enable trzsz detect trace logs for debugging"`

--- a/tssh/args_test.go
+++ b/tssh/args_test.go
@@ -146,16 +146,6 @@ func TestSshArgs(t *testing.T) {
 	}
 }
 
-func TestControlCommands(t *testing.T) {
-	assert := assert.New(t)
-	for _, cmd := range []string{"check", "forward", "cancel", "exit", "stop", "proxy"} {
-		assert.True(validControlCommands[cmd], "expected [%s] to be a valid control command", cmd)
-	}
-	for _, cmd := range []string{"", "bogus", "Exit", "restart"} {
-		assert.False(validControlCommands[cmd], "expected [%s] to be rejected", cmd)
-	}
-}
-
 func TestForwardArgs(t *testing.T) {
 	assert := assert.New(t)
 	assertDynamicForwardNil := func(argument string, address *string, port int) {

--- a/tssh/args_test.go
+++ b/tssh/args_test.go
@@ -67,6 +67,9 @@ func TestSshArgs(t *testing.T) {
 	assertArgsEqual("-x", sshArgs{NoX11Forward: true})
 	assertArgsEqual("-Y", sshArgs{X11Trusted: true})
 	assertArgsEqual("-S none", sshArgs{ControlPath: "none"})
+	assertArgsEqual("-O exit host", sshArgs{ControlCmd: "exit", Destination: "host"})
+	assertArgsEqual("-O check host", sshArgs{ControlCmd: "check", Destination: "host"})
+	assertArgsEqual("-Ostop host", sshArgs{ControlCmd: "stop", Destination: "host"})
 
 	assertArgsEqual("-p1022", sshArgs{Port: 1022})
 	assertArgsEqual("-p 2049", sshArgs{Port: 2049})
@@ -140,6 +143,16 @@ func TestSshArgs(t *testing.T) {
 
 	if got := assertArgsError("-v", arg.ErrVersion.Error()); got != arg.ErrVersion {
 		t.Errorf("-v expected error %v, got %v", arg.ErrVersion, got)
+	}
+}
+
+func TestControlCommands(t *testing.T) {
+	assert := assert.New(t)
+	for _, cmd := range []string{"check", "forward", "cancel", "exit", "stop", "proxy"} {
+		assert.True(validControlCommands[cmd], "expected [%s] to be a valid control command", cmd)
+	}
+	for _, cmd := range []string{"", "bogus", "Exit", "restart"} {
+		assert.False(validControlCommands[cmd], "expected [%s] to be rejected", cmd)
 	}
 }
 

--- a/tssh/ctrl_unix.go
+++ b/tssh/ctrl_unix.go
@@ -322,113 +322,40 @@ func startControlMaster(param *sshParam, sshPath string) error {
 	return nil
 }
 
-// resolveControlSocket resolves the native ssh program and the control socket
-// path the same way connectViaControl does: read ControlPath from args or the
-// effective config, then expand the version-gated token set and the home directory.
-func resolveControlSocket(param *sshParam) (sshPath, socket string, err error) {
-	args := param.args
-	ctrlPath := args.ControlPath
-	if ctrlPath == "" {
-		ctrlPath = getOptionConfig(args, "ControlPath")
-	}
-	switch strings.ToLower(ctrlPath) {
-	case "", "none":
-		return "", "", fmt.Errorf("no ControlPath configured")
-	}
-
-	sshPath, majorVersion, minorVersion, err := getOpenSSH()
+// execControlCmd forwards an OpenSSH multiplexing control command (`tssh -O <ctl_cmd>`)
+// to the native ssh master process and propagates its exit code.
+func execControlCmd(args *sshArgs, dest string) int {
+	cmdArgs, err := replaceOrAppendDest(os.Args[1:], args.Destination, dest)
 	if err != nil {
-		return "", "", fmt.Errorf("can't find openssh program: %v", err)
-	}
-	if majorVersion < 0 || minorVersion < 0 {
-		return "", "", fmt.Errorf("can't get openssh version of %s", sshPath)
+		warning("replace or append destination failed: %v", err)
+		return kExitCodeToolsError
 	}
 
-	tokens := "%CdhijkLlnpru"
-	if majorVersion < 9 || (majorVersion == 9 && minorVersion < 6) {
-		tokens = "%CdhikLlnpru"
-	}
-	socket, err = expandTokens(ctrlPath, param, tokens)
+	sshPath, _, _, err := getOpenSSH()
 	if err != nil {
-		return "", "", fmt.Errorf("expand ControlPath [%s] failed: %v", ctrlPath, err)
+		warning("can't find openssh program: %v", err)
+		return kExitCodeToolsError
 	}
-	return sshPath, resolveHomeDir(socket), nil
-}
-
-// execControlCmd forwards an OpenSSH multiplexing control command
-// (`tssh -O <ctl_cmd> <destination>`) to the native ssh master process
-// listening on the resolved ControlPath socket, and propagates its exit code.
-func execControlCmd(args *sshArgs) (int, bool) {
-	ctlCmd := strings.ToLower(strings.TrimSpace(args.ControlCmd))
-	if !validControlCommands[ctlCmd] {
-		warning("unsupported control command [%s], expected one of: check, forward, cancel, exit, stop, proxy", args.ControlCmd)
-		return kExitCodeArgsInvalid, true
-	}
-
-	if args.Destination == "" {
-		warning("a destination is required to control the multiplexing master process")
-		return kExitCodeNoDestHost, true
-	}
-
-	param, err := getSshParam(args, false)
-	if err != nil {
-		warning("get ssh param failed: %v", err)
-		return kExitCodeArgsInvalid, true
-	}
-
-	sshPath, socket, err := resolveControlSocket(param)
-	if err != nil {
-		warning("can't control the multiplexing master process: %v", err)
-		return kExitCodeArgsInvalid, true
-	}
-
-	cmdArgs := []string{"-O", ctlCmd, "-S", socket}
-	// `forward` and `cancel` act on specific forwarding specs, so pass the
-	// requested forwarding arguments and the options that shape them through
-	// to the native ssh master (mirroring startControlMaster).
-	if ctlCmd == "forward" || ctlCmd == "cancel" {
-		if args.Gateway {
-			cmdArgs = append(cmdArgs, "-g")
-		}
-		if args.ConfigFile != "" {
-			cmdArgs = append(cmdArgs, "-F", args.ConfigFile)
-		}
-		for key, values := range args.Option.options {
-			if key == "remotecommand" {
-				continue
-			}
-			for _, value := range values {
-				cmdArgs = append(cmdArgs, fmt.Sprintf("-o%s=%s", key, value))
-			}
-		}
-		for _, b := range args.DynamicForward.binds {
-			cmdArgs = append(cmdArgs, "-D", b.argument)
-		}
-		for _, f := range args.LocalForward.cfgs {
-			cmdArgs = append(cmdArgs, "-L", f.argument)
-		}
-		for _, f := range args.RemoteForward.cfgs {
-			cmdArgs = append(cmdArgs, "-R", f.argument)
-		}
-	}
-	cmdArgs = append(cmdArgs, args.Destination)
 
 	cmd := exec.Command(sshPath, cmdArgs...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+
 	if enableDebugLogging {
 		debug("control command: %s %s", sshPath, strings.Join(cmdArgs, " "))
 	}
+
 	if err := cmd.Run(); err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			return exitErr.ExitCode(), true
+			return exitErr.ExitCode()
 		}
-		warning("control command [%s] failed: %v", ctlCmd, err)
-		return kExitCodeToolsError, true
+		warning("control command %v failed: %v", cmdArgs, err)
+		return kExitCodeToolsError
 	}
-	return 0, true
+
+	return 0
 }
 
 func connectViaControl(param *sshParam) SshClient {

--- a/tssh/ctrl_unix.go
+++ b/tssh/ctrl_unix.go
@@ -29,6 +29,7 @@ package tssh
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -319,6 +320,115 @@ func startControlMaster(param *sshParam, sshPath string) error {
 	}
 	debug("start control master success")
 	return nil
+}
+
+// resolveControlSocket resolves the native ssh program and the control socket
+// path the same way connectViaControl does: read ControlPath from args or the
+// effective config, then expand the version-gated token set and the home directory.
+func resolveControlSocket(param *sshParam) (sshPath, socket string, err error) {
+	args := param.args
+	ctrlPath := args.ControlPath
+	if ctrlPath == "" {
+		ctrlPath = getOptionConfig(args, "ControlPath")
+	}
+	switch strings.ToLower(ctrlPath) {
+	case "", "none":
+		return "", "", fmt.Errorf("no ControlPath configured")
+	}
+
+	sshPath, majorVersion, minorVersion, err := getOpenSSH()
+	if err != nil {
+		return "", "", fmt.Errorf("can't find openssh program: %v", err)
+	}
+	if majorVersion < 0 || minorVersion < 0 {
+		return "", "", fmt.Errorf("can't get openssh version of %s", sshPath)
+	}
+
+	tokens := "%CdhijkLlnpru"
+	if majorVersion < 9 || (majorVersion == 9 && minorVersion < 6) {
+		tokens = "%CdhikLlnpru"
+	}
+	socket, err = expandTokens(ctrlPath, param, tokens)
+	if err != nil {
+		return "", "", fmt.Errorf("expand ControlPath [%s] failed: %v", ctrlPath, err)
+	}
+	return sshPath, resolveHomeDir(socket), nil
+}
+
+// execControlCmd forwards an OpenSSH multiplexing control command
+// (`tssh -O <ctl_cmd> <destination>`) to the native ssh master process
+// listening on the resolved ControlPath socket, and propagates its exit code.
+func execControlCmd(args *sshArgs) (int, bool) {
+	ctlCmd := strings.ToLower(strings.TrimSpace(args.ControlCmd))
+	if !validControlCommands[ctlCmd] {
+		warning("unsupported control command [%s], expected one of: check, forward, cancel, exit, stop, proxy", args.ControlCmd)
+		return kExitCodeArgsInvalid, true
+	}
+
+	if args.Destination == "" {
+		warning("a destination is required to control the multiplexing master process")
+		return kExitCodeNoDestHost, true
+	}
+
+	param, err := getSshParam(args, false)
+	if err != nil {
+		warning("get ssh param failed: %v", err)
+		return kExitCodeArgsInvalid, true
+	}
+
+	sshPath, socket, err := resolveControlSocket(param)
+	if err != nil {
+		warning("can't control the multiplexing master process: %v", err)
+		return kExitCodeArgsInvalid, true
+	}
+
+	cmdArgs := []string{"-O", ctlCmd, "-S", socket}
+	// `forward` and `cancel` act on specific forwarding specs, so pass the
+	// requested forwarding arguments and the options that shape them through
+	// to the native ssh master (mirroring startControlMaster).
+	if ctlCmd == "forward" || ctlCmd == "cancel" {
+		if args.Gateway {
+			cmdArgs = append(cmdArgs, "-g")
+		}
+		if args.ConfigFile != "" {
+			cmdArgs = append(cmdArgs, "-F", args.ConfigFile)
+		}
+		for key, values := range args.Option.options {
+			if key == "remotecommand" {
+				continue
+			}
+			for _, value := range values {
+				cmdArgs = append(cmdArgs, fmt.Sprintf("-o%s=%s", key, value))
+			}
+		}
+		for _, b := range args.DynamicForward.binds {
+			cmdArgs = append(cmdArgs, "-D", b.argument)
+		}
+		for _, f := range args.LocalForward.cfgs {
+			cmdArgs = append(cmdArgs, "-L", f.argument)
+		}
+		for _, f := range args.RemoteForward.cfgs {
+			cmdArgs = append(cmdArgs, "-R", f.argument)
+		}
+	}
+	cmdArgs = append(cmdArgs, args.Destination)
+
+	cmd := exec.Command(sshPath, cmdArgs...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if enableDebugLogging {
+		debug("control command: %s %s", sshPath, strings.Join(cmdArgs, " "))
+	}
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return exitErr.ExitCode(), true
+		}
+		warning("control command [%s] failed: %v", ctlCmd, err)
+		return kExitCodeToolsError, true
+	}
+	return 0, true
 }
 
 func connectViaControl(param *sshParam) SshClient {

--- a/tssh/ctrl_windows.go
+++ b/tssh/ctrl_windows.go
@@ -30,6 +30,11 @@ import (
 
 const kOpenSSH = "ssh.exe"
 
+func execControlCmd(args *sshArgs) (int, bool) {
+	warning("controlling the multiplexing master process is not supported on Windows")
+	return kExitCodeToolsError, true
+}
+
 func connectViaControl(param *sshParam) SshClient {
 	ctrlMaster := getOptionConfig(param.args, "ControlMaster")
 	ctrlPath := param.args.ControlPath

--- a/tssh/ctrl_windows.go
+++ b/tssh/ctrl_windows.go
@@ -30,9 +30,9 @@ import (
 
 const kOpenSSH = "ssh.exe"
 
-func execControlCmd(args *sshArgs) (int, bool) {
+func execControlCmd(_ *sshArgs, _ string) int {
 	warning("controlling the multiplexing master process is not supported on Windows")
-	return kExitCodeToolsError, true
+	return kExitCodeToolsError
 }
 
 func connectViaControl(param *sshParam) SshClient {

--- a/tssh/main.go
+++ b/tssh/main.go
@@ -105,7 +105,9 @@ func replaceOrAppendDest(args []string, oldDest, newDest string) ([]string, erro
 
 	if oldDest == "" {
 		// No existing destination, append the new one
-		newArgs = append(newArgs, newDest)
+		if newDest != "" {
+			newArgs = append(newArgs, newDest)
+		}
 	} else if oldDest != newDest {
 		// Replace old destination
 		idx := -1
@@ -304,19 +306,18 @@ func TsshMain(argv []string) int {
 	// choose ssh alias
 	dest := ""
 	quit := false
-	if args.Destination == "" || args.Destination == "FAKE_DEST_IN_WARP" {
-		if !isTerminal {
-			fmt.Fprintln(os.Stderr, "destination is required when running tssh in non-interactive mode")
-			return kExitCodeNoDestHost
-		}
-		dest, quit, err = chooseAlias(&args, "")
-	} else {
-		dest, quit, err = predictDestination(&args, args.Destination)
-	}
+	dest, quit, err = chooseOrPredictDest(&args)
 	if quit {
 		err = nil
 		return 0
 	}
+
+	// multiplexing control command
+	if args.ControlCmd != "" {
+		return execControlCmd(&args, dest)
+	}
+
+	// check dest before startup
 	if err != nil || dest == "" {
 		if err == nil {
 			err = fmt.Errorf("missing destination host")

--- a/tssh/prompt.go
+++ b/tssh/prompt.go
@@ -671,3 +671,18 @@ func predictDestination(args *sshArgs, dest string) (string, bool, error) {
 
 	return chooseAlias(args, dest)
 }
+
+func chooseOrPredictDest(args *sshArgs) (string, bool, error) {
+	if args.ControlCmd != "" && args.ControlPath != "" {
+		return args.Destination, false, nil
+	}
+
+	if args.Destination == "" || args.Destination == "FAKE_DEST_IN_WARP" {
+		if !isTerminal {
+			return "", false, fmt.Errorf("destination is required when running tssh in non-interactive mode")
+		}
+		return chooseAlias(args, "")
+	}
+
+	return predictDestination(args, args.Destination)
+}

--- a/tssh/tools.go
+++ b/tssh/tools.go
@@ -524,26 +524,12 @@ func isFileNotExistOrEmpty(path string) bool {
 	return stat.Size() == 0
 }
 
-// validControlCommands are the OpenSSH `-O <ctl_cmd>` commands that may be
-// forwarded to the native ssh multiplexing master process. Defined in a
-// platform-neutral file so both the Unix handler and the tests can reference it.
-var validControlCommands = map[string]bool{
-	"check":   true,
-	"forward": true,
-	"cancel":  true,
-	"exit":    true,
-	"stop":    true,
-	"proxy":   true,
-}
-
 // execLocalTools execute local tools if necessary
 //
 // return true to quit with return code
 // return false to continue ssh login
 func execLocalTools(args *sshArgs) (int, bool) {
 	switch {
-	case args.ControlCmd != "":
-		return execControlCmd(args)
 	case args.EncSecret:
 		return execEncodeSecret()
 	case args.NewHost || args.Destination == "" && isFileNotExistOrEmpty(userConfig.configPath):

--- a/tssh/tools.go
+++ b/tssh/tools.go
@@ -524,12 +524,26 @@ func isFileNotExistOrEmpty(path string) bool {
 	return stat.Size() == 0
 }
 
+// validControlCommands are the OpenSSH `-O <ctl_cmd>` commands that may be
+// forwarded to the native ssh multiplexing master process. Defined in a
+// platform-neutral file so both the Unix handler and the tests can reference it.
+var validControlCommands = map[string]bool{
+	"check":   true,
+	"forward": true,
+	"cancel":  true,
+	"exit":    true,
+	"stop":    true,
+	"proxy":   true,
+}
+
 // execLocalTools execute local tools if necessary
 //
 // return true to quit with return code
 // return false to continue ssh login
 func execLocalTools(args *sshArgs) (int, bool) {
 	switch {
+	case args.ControlCmd != "":
+		return execControlCmd(args)
 	case args.EncSecret:
 		return execEncodeSecret()
 	case args.NewHost || args.Destination == "" && isFileNotExistOrEmpty(userConfig.configPath):


### PR DESCRIPTION
## Summary

Adds `-O <ctl_cmd>` to control an already-running multiplexing master process, giving tssh parity with `ssh -O` (#254). The flag accepts the OpenSSH control commands `check`, `forward`, `cancel`, `exit`, `stop`, and `proxy`, validates the value, resolves the control socket exactly the way the existing multiplexing login path does, and forwards the request to the native ssh master, propagating its exit code.

## Why this matters

The maintainer described the intended design in the issue: officially support `-O <ctl_cmd>` and, under the hood, "essentially just forward these specific parameters" to the native ssh master process. This change implements that approach. tssh already shells out to native OpenSSH for `ControlMaster`, so controlling that master is a natural extension and lets users `check` or tear down a master without hand-building the socket path.

Details:
- `tssh/args.go`: new `-O/--ControlCmd` flag (`placeholder:"ctl_cmd"`).
- `tssh/tools.go`: `execLocalTools` short-circuits to the handler before login; the validated control-command set lives here so it is platform-neutral.
- `tssh/ctrl_unix.go`: `execControlCmd` resolves the socket like `connectViaControl` (version-gated token expansion + home-dir resolution) and runs `ssh -O <ctl_cmd> -S <socket> <dest>`. For `forward`/`cancel` it also forwards the `-g`, `-F`, `-o`, and `-D/-L/-R` arguments that shape the forwarding request.
- `tssh/ctrl_windows.go`: a counterpart that reports multiplexing control is unsupported, so the shared dispatch builds on both platforms.

Invalid commands, a missing destination, and a missing/`none` `ControlPath` produce a clear warning instead of a panic.

## Testing

- `go test ./tssh/...` (includes new `-O` parsing assertions and a control-command validation test)
- `go vet ./tssh/...` and `gofmt -l` clean
- `go build ./...` and `GOOS=windows go build ./...` both succeed

Fixes #254
