### PR TITLE
fix: skip Windows virtual terminal setup when stdout is piped

### DIFF
--- a/tssh/main.go
+++ b/tssh/main.go
@@ -241,7 +241,11 @@ func addOnCloseFunc(f func()) {
 	onCloseFuncs = append(onCloseFuncs, f)
 }
 
-var isTerminal bool = isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd())
+func isTerminalFd(fd uintptr) bool {
+	return isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)
+}
+
+var isTerminal bool = isTerminalFd(os.Stdin.Fd())
 
 // TrzMain is the main function of tssh program.
 func TsshMain(argv []string) int {

--- a/tssh/term_windows.go
+++ b/tssh/term_windows.go
@@ -84,6 +84,10 @@ func enableVirtualTerminal() error {
 		return err
 	}
 
+	if !isTerminalFd(os.Stdout.Fd()) {
+		return nil
+	}
+
 	outHandle, err := syscall.GetStdHandle(syscall.STD_OUTPUT_HANDLE)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fix `tssh --list-hosts | rg ...` on Windows.

When stdin is interactive but stdout is piped, `setupVirtualTerminal()` still tried to enable Windows virtual terminal mode on `STD_OUTPUT_HANDLE`. Since stdout is a pipe in that case, `GetConsoleMode` failed with `The handle is invalid.`

This keeps the existing stdin-based interactivity check, but only enables Windows virtual terminal mode when stdout is also a terminal.