### PR TITLE
fix: ignore malformed known_hosts entries

### DIFF
--- a/tssh/known_hosts.go
+++ b/tssh/known_hosts.go
@@ -30,11 +30,13 @@ import (
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -48,6 +50,137 @@ var acceptHostKeys []string
 var acceptHostKeyMu sync.Mutex
 var addHostKeyMutex sync.Mutex
 var sshLoginSuccess atomic.Bool
+
+type malformedKnownHost struct {
+	path   string
+	line   int
+	reason string
+}
+
+type knownHostsSnapshot struct {
+	originalPath  string
+	temporaryPath string
+	lines         [][]byte
+}
+
+func createKnownHostsSnapshots(files []string) ([]*knownHostsSnapshot, error) {
+	snapshots := make([]*knownHostsSnapshot, 0, len(files))
+	cleanup := func() {
+		for _, snapshot := range snapshots {
+			_ = os.Remove(snapshot.temporaryPath)
+		}
+	}
+
+	for _, path := range files {
+		input, err := os.ReadFile(path)
+		if err != nil {
+			cleanup()
+			return nil, err
+		}
+
+		file, err := os.CreateTemp("", "tssh_known_hosts_*")
+		if err != nil {
+			cleanup()
+			return nil, err
+		}
+		temporaryPath := file.Name()
+		if err := writeAll(file, input); err != nil {
+			_ = file.Close()
+			_ = os.Remove(temporaryPath)
+			cleanup()
+			return nil, err
+		}
+		if err := file.Close(); err != nil {
+			_ = os.Remove(temporaryPath)
+			cleanup()
+			return nil, err
+		}
+
+		snapshots = append(snapshots, &knownHostsSnapshot{
+			originalPath:  path,
+			temporaryPath: temporaryPath,
+			lines:         bytes.Split(input, []byte{'\n'}),
+		})
+	}
+	return snapshots, nil
+}
+
+func parseKnownHostsLineError(err error, snapshots []*knownHostsSnapshot) (*knownHostsSnapshot, int, string, bool) {
+	message := err.Error()
+	for _, snapshot := range snapshots {
+		prefix := "knownhosts: " + snapshot.temporaryPath + ":"
+		if !strings.HasPrefix(message, prefix) {
+			continue
+		}
+		remainder := strings.TrimPrefix(message, prefix)
+		lineText, reason, ok := strings.Cut(remainder, ":")
+		if !ok {
+			return nil, 0, "", false
+		}
+		line, parseErr := strconv.Atoi(lineText)
+		if parseErr != nil || line < 1 || line > len(snapshot.lines) {
+			return nil, 0, "", false
+		}
+		return snapshot, line, strings.TrimSpace(reason), true
+	}
+	return nil, 0, "", false
+}
+
+func rewriteKnownHostsSnapshot(snapshot *knownHostsSnapshot) error {
+	return os.WriteFile(snapshot.temporaryPath, bytes.Join(snapshot.lines, []byte{'\n'}), 0600)
+}
+
+func restoreKnownHostsPaths(err error, snapshots []*knownHostsSnapshot) error {
+	message := err.Error()
+	for _, snapshot := range snapshots {
+		message = strings.ReplaceAll(message, snapshot.temporaryPath, snapshot.originalPath)
+	}
+	return errors.New(message)
+}
+
+func newKnownHostsDB(files ...string) (*knownhosts.HostKeyDB, []malformedKnownHost, error) {
+	db, err := knownhosts.NewDB(files...)
+	if err == nil {
+		return db, nil, nil
+	}
+
+	snapshots, snapshotErr := createKnownHostsSnapshots(files)
+	if snapshotErr != nil {
+		return nil, nil, snapshotErr
+	}
+	defer func() {
+		for _, snapshot := range snapshots {
+			_ = os.Remove(snapshot.temporaryPath)
+		}
+	}()
+
+	temporaryFiles := make([]string, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		temporaryFiles = append(temporaryFiles, snapshot.temporaryPath)
+	}
+
+	var malformed []malformedKnownHost
+	for {
+		db, err = knownhosts.NewDB(temporaryFiles...)
+		if err == nil {
+			return db, malformed, nil
+		}
+
+		snapshot, line, reason, ok := parseKnownHostsLineError(err, snapshots)
+		if !ok {
+			return nil, nil, restoreKnownHostsPaths(err, snapshots)
+		}
+		snapshot.lines[line-1] = nil
+		if err := rewriteKnownHostsSnapshot(snapshot); err != nil {
+			return nil, nil, err
+		}
+		malformed = append(malformed, malformedKnownHost{
+			path:   snapshot.originalPath,
+			line:   line,
+			reason: reason,
+		})
+	}
+}
 
 func isAcceptedHostKey(keyNormalizedLine string) bool {
 	acceptHostKeyMu.Lock()
@@ -216,9 +349,12 @@ func getHostKeyCallback(param *sshParam) (ssh.HostKeyCallback, []string, error) 
 		return nil, nil, err
 	}
 
-	khdb, err := knownhosts.NewDB(files...)
+	khdb, malformed, err := newKnownHostsDB(files...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("new knownhosts failed: %v", err)
+	}
+	for _, entry := range malformed {
+		warning("Ignoring malformed known_hosts entry %s:%d: %s", entry.path, entry.line, entry.reason)
 	}
 
 	hostKeyCallback := func(host string, remote net.Addr, key ssh.PublicKey) (err error) {

--- a/tssh/known_hosts_test.go
+++ b/tssh/known_hosts_test.go
@@ -1,0 +1,149 @@
+/*
+MIT License
+
+Copyright (c) 2023-2026 The Trzsz SSH Authors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package tssh
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/skeema/knownhosts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+	xkh "golang.org/x/crypto/ssh/knownhosts"
+)
+
+func newKnownHostsTestKey(t *testing.T) ssh.PublicKey {
+	t.Helper()
+	public, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	key, err := ssh.NewPublicKey(public)
+	require.NoError(t, err)
+	return key
+}
+
+func writeKnownHostsTestFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+	return path
+}
+
+func checkKnownHostsTestKey(db *knownhosts.HostKeyDB, host string, port int, key ssh.PublicKey) error {
+	return db.HostKeyCallback()(net.JoinHostPort(host, strconv.Itoa(port)),
+		&net.TCPAddr{IP: net.ParseIP("192.0.2.1"), Port: port}, key)
+}
+
+func TestNewKnownHostsDBIgnoresMalformedEntries(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("TMPDIR", tempDir)
+	key := newKnownHostsTestKey(t)
+	validLine := knownhosts.Line([]string{"valid.example"}, key)
+	malformedLine := "broken.example ssh-rsa not-base64 ssh-rsa " + strings.Repeat("A", 372)
+	content := "# retained comment\n" + malformedLine + "\n" + validLine + "\n"
+	path := writeKnownHostsTestFile(t, tempDir, "known_hosts", content)
+
+	db, malformed, err := newKnownHostsDB(path)
+	require.NoError(t, err)
+	require.Len(t, malformed, 1)
+	assert.Equal(t, path, malformed[0].path)
+	assert.Equal(t, 2, malformed[0].line)
+	assert.Contains(t, malformed[0].reason, "illegal base64")
+	assert.NotContains(t, malformed[0].reason, strings.Repeat("A", 32))
+	assert.NoError(t, checkKnownHostsTestKey(db, "valid.example", 22, key))
+
+	after, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(after))
+	entries, err := os.ReadDir(tempDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "known_hosts", entries[0].Name())
+}
+
+func TestNewKnownHostsDBIgnoresMultipleMalformedEntries(t *testing.T) {
+	tempDir := t.TempDir()
+	key := newKnownHostsTestKey(t)
+	first := writeKnownHostsTestFile(t, tempDir, "known_hosts", "first ssh-ed25519 !!!\n")
+	second := writeKnownHostsTestFile(t, tempDir, "known_hosts2",
+		"second ssh-rsa !!!\n"+knownhosts.Line([]string{"valid.example"}, key)+"\n")
+
+	db, malformed, err := newKnownHostsDB(first, second)
+	require.NoError(t, err)
+	require.Len(t, malformed, 2)
+	assert.Equal(t, first, malformed[0].path)
+	assert.Equal(t, second, malformed[1].path)
+	assert.NoError(t, checkKnownHostsTestKey(db, "valid.example", 22, key))
+}
+
+func TestNewKnownHostsDBPreservesEnhancedMatching(t *testing.T) {
+	tempDir := t.TempDir()
+	key := newKnownHostsTestKey(t)
+	revokedKey := newKnownHostsTestKey(t)
+	hashedHost := "hashed.example"
+	content := strings.Join([]string{
+		"broken ssh-ed25519 !!!",
+		knownhosts.Line([]string{"*.example.com"}, key),
+		knownhosts.Line([]string{xkh.HashHostname(hashedHost)}, key),
+		"@cert-authority " + knownhosts.Line([]string{"cert.example"}, key),
+		"@revoked " + knownhosts.Line([]string{"revoked.example"}, revokedKey),
+	}, "\n") + "\n"
+	path := writeKnownHostsTestFile(t, tempDir, "known_hosts", content)
+
+	db, malformed, err := newKnownHostsDB(path)
+	require.NoError(t, err)
+	require.Len(t, malformed, 1)
+	assert.NoError(t, db.HostKeyCallback()("wild.example.com:2222",
+		&net.TCPAddr{IP: net.ParseIP("192.0.2.1"), Port: 2222}, key))
+	assert.NoError(t, checkKnownHostsTestKey(db, hashedHost, 22, key))
+	assert.Contains(t, db.HostKeyAlgorithms("cert.example:22"), ssh.CertAlgoED25519v01)
+
+	err = checkKnownHostsTestKey(db, "revoked.example", 22, revokedKey)
+	var revokedErr *xkh.RevokedError
+	assert.True(t, errors.As(err, &revokedErr))
+}
+
+func TestNewKnownHostsDBWithOnlyMalformedEntries(t *testing.T) {
+	path := writeKnownHostsTestFile(t, t.TempDir(), "known_hosts", "broken ssh-ed25519 !!!\n")
+	db, malformed, err := newKnownHostsDB(path)
+	require.NoError(t, err)
+	require.Len(t, malformed, 1)
+
+	err = checkKnownHostsTestKey(db, "unknown.example", 22, newKnownHostsTestKey(t))
+	assert.True(t, knownhosts.IsHostUnknown(err))
+}
+
+func TestNewKnownHostsDBKeepsNonParseErrorsFatal(t *testing.T) {
+	_, malformed, err := newKnownHostsDB(t.TempDir())
+	require.Error(t, err)
+	assert.Nil(t, malformed)
+}


### PR DESCRIPTION
## Summary
- keep loading valid host keys when an unrelated known_hosts line is malformed
- warn with the original file and line while leaving the user file unchanged
- preserve hashed hosts, wildcards, certificate authorities, and revoked-key behavior

## Reproduction
A known_hosts line containing a malformed base64 key currently makes knownhosts.NewDB abort every connection, even when the requested host has a separate valid entry. OpenSSH skips the malformed line and continues.

## Testing
- go test ./tssh -run TestNewKnownHostsDB -count=1
- go vet ./...
- go build -o /tmp/tssh-knownhosts-fix ./cmd/tssh
- real batch-mode connection using a known_hosts file with the malformed line: warning emitted and connection exited 0

The full suite passes with TestTableExample skipped; that unrelated golden test currently receives ANSI-colored Lipgloss output while expecting plain text in this terminal environment.