### PR TITLE
feat: add ClientAutoUpload config to accept automatic upload

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -388,6 +388,20 @@ trzsz-ssh ( tssh ) 与 [tsshd](https://github.com/trzsz/tsshd) 一起，适用�
   tssh --upload-file /path/to/file1 --upload-file /path/to/dir2 xxx_server '~/.local/bin/trz -d /tmp/'
   ```
 
+- 在 `~/.ssh/config` 或 `ExConfigPath` 配置文件中，配置 `ClientAutoUpload` 为 `yes`，允许服务器通过 `trz --local-path` 免弹窗自动上传文件（默认不开启，服务器请求自动上传时仍会弹出文件选择框）：
+
+  ```
+  Host xxx
+    # 如果配置在 ~/.ssh/config 中，可以加上 `#!!` 前缀，以兼容标准 ssh
+    ClientAutoUpload yes
+  ```
+
+- 服务器上需安装支持 `--local-path` 的 [trzsz](https://trzsz.github.io/cn/go) 版本，并在服务器的 `~/.trzsz.conf` 中配置 `LocalPathUpload = true`，然后在服务器上执行 `trz --local-path` 即可免弹窗自动上传文件或目录，如：
+
+  ```sh
+  trz --local-path /path/to/file1,/path/to/dir2 /tmp/
+  ```
+
 - 可在命令行中使用 `tsz` 直接下载文件或目录到本地，可一并使用 `--download-path` 参数指定本地保存的路径，如：
 
   ```sh

--- a/README.en.md
+++ b/README.en.md
@@ -389,6 +389,20 @@ trzsz-ssh ( tssh ) with [tsshd](https://github.com/trzsz/tsshd) also supports in
   tssh --upload-file /path/to/file1 --upload-file /path/to/dir2 xxx_server '~/.local/bin/trz -d /tmp/'
   ```
 
+- In the `~/.ssh/config` or `ExConfigPath` configuration file, configure `ClientAutoUpload` to `yes` to allow the server to upload files and directories automatically via `trz --local-path` without popping up the file selection dialog ( disabled by default, the file selection dialog will still pop up when the server requests an automatic upload ):
+
+  ```
+  Host xxx
+    # If configured in ~/.ssh/config, add `#!!` prefix to be compatible with openssh.
+    ClientAutoUpload yes
+  ```
+
+- The server should install the [trzsz](https://trzsz.github.io/go) version that supports `--local-path`, and configure `LocalPathUpload = true` in the server's `~/.trzsz.conf`, then run `trz --local-path` on the server to upload files and directories automatically without popping up the file selection dialog, such as:
+
+  ```sh
+  trz --local-path /path/to/file1,/path/to/dir2 /tmp/
+  ```
+
 - You can use `tsz` in the command line to directly download files and directories to your local computer. You can also use the `--download-path` argument to specify the path for local saving, such as:
 
   ```sh

--- a/tssh/config.go
+++ b/tssh/config.go
@@ -86,6 +86,7 @@ type tsshConfig struct {
 	defaultUploadPath     string
 	defaultDownloadPath   string
 	dragFileUploadCommand string
+	clientAutoUpload      *bool
 	progressColorPair     string
 	promptThemeLayout     string
 	promptThemeColors     map[string]string
@@ -209,6 +210,8 @@ func loadTsshConfig(path string) {
 			userConfig.exConfigPath = resolveHomeDir(value)
 		case name == "useopensshconfig" && userConfig.useOpenSSHConfig == nil:
 			userConfig.useOpenSSHConfig = parseBoolValue(name, value, false)
+		case name == "clientautoupload" && userConfig.clientAutoUpload == nil:
+			userConfig.clientAutoUpload = parseBoolValue(name, value, false)
 		case name == "fuzzyhostselection" && userConfig.fuzzyHostSelection == nil:
 			userConfig.fuzzyHostSelection = parseBoolValue(name, value, true)
 		case name == "defaultuploadpath" && userConfig.defaultUploadPath == "":
@@ -279,6 +282,9 @@ func showTsshConfig() {
 	}
 	if userConfig.useOpenSSHConfig != nil {
 		debug("UseOpenSSHConfig = %v", *userConfig.useOpenSSHConfig)
+	}
+	if userConfig.clientAutoUpload != nil {
+		debug("ClientAutoUpload = %v", *userConfig.clientAutoUpload)
 	}
 	if userConfig.fuzzyHostSelection != nil {
 		debug("FuzzyHostSelection = %v", *userConfig.fuzzyHostSelection)

--- a/tssh/trzsz.go
+++ b/tssh/trzsz.go
@@ -144,6 +144,9 @@ func setupTrzszFilter(sshConn *sshConnection) error {
 	trzszFilter.SetDefaultDownloadPath(defaultDownloadPath)
 	trzszFilter.SetDragFileUploadCommand(dragFileUploadCommand)
 	trzszFilter.SetProgressColorPair(userConfig.progressColorPair)
+	if userConfig.clientAutoUpload != nil {
+		trzszFilter.SetClientAutoUpload(*userConfig.clientAutoUpload)
+	}
 
 	// setup tunnel connect
 	trzszFilter.SetTunnelConnector(func(port int) net.Conn {


### PR DESCRIPTION
## Summary

Add a `ClientAutoUpload` config ( `~/.ssh/config` or `ExConfigPath` ) to allow the server to upload files and directories automatically via `trz --local-path` without popping up the file selection dialog.

## Changes

- New `ClientAutoUpload` config, disabled by default — when disabled, the server's automatic upload request is rejected with a hint message and the file selection dialog is still used
- Works with the companion PR in trzsz/trzsz-go ( `LocalPathUpload` config + `trz --local-path` )
- README ( CN / EN ) updated

## Note

This implementation is based on AI-generated code.
